### PR TITLE
chore: fix release to Hex

### DIFF
--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -18,7 +18,7 @@ jobs:
       matrix:
         otp: ["23"]
         elixir: ["1.11.0"]
-        ash: ["master", "1.30.1"]
+        ash: ["master", "1.37.2"]
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       ASH_VERSION: ${{matrix.ash}}


### PR DESCRIPTION
Bump to ash 1.37.2 in build matrix to match `mix.exs`.
 
`ash_json_api` since v0.27.1 has failed to publish to [Hex](https://hex.pm/packages/ash_json_api) due to the build matrix failing on Ash 1.30.1. The release action is skipped because it depends on the full build matrix passing.